### PR TITLE
fix multiple emojis in a row causing additional empty tokens being added

### DIFF
--- a/lib/rfc2047.js
+++ b/lib/rfc2047.js
@@ -246,7 +246,8 @@ rfc2047.encode = (text) => {
         }
 
         // Word contains at least one header unsafe char, an encoded word must be created.
-        if (token.length > maxNumCharsPerEncodedWord) {
+        // Don't check string length directly as emojis can be longer than 1 char.
+        if ([...token].length > maxNumCharsPerEncodedWord) {
           nextTokenMustBeEncoded = true;
           const chars = [...token];
           tokens.splice(

--- a/test/rfc2047.js
+++ b/test/rfc2047.js
@@ -50,9 +50,9 @@ describe('rfc2047', () => {
         // https://github.com/One-com/rfc2047/issues/11
         it('should handle a string with multiple emojis in a row', () => {
           expect(
-            'Seven hills😍🦌',
+            'Seven hills 😍🦌😍🦌😍 no extra spaces',
             'to encode back and forth to',
-            'Seven =?utf-8?Q?hills=F0=9F=98=8D=F0=9F=A6=8C?='
+            'Seven hills =?utf-8?Q?=F0=9F=98=8D=F0=9F=A6=8C=F0=9F=98=8D=F0=9F=A6=8C=F0=9F=98=8D?= no extra spaces'
           );
         });
 


### PR DESCRIPTION
Fix multiple emojis in a row causing empty tokens being added to the list being iterated.

Issue is that emojis can can count as multiple characters when doing `"string".length` as it checks the count of UTF-16 units.

Fix this by spreading the string to a list and checking the list length.

closes: https://github.com/One-com/rfc2047/issues/15